### PR TITLE
Remove the logging.basicConfig call from the listen_for_events function

### DIFF
--- a/certstream/cli.py
+++ b/certstream/cli.py
@@ -14,12 +14,19 @@ parser = argparse.ArgumentParser(description='Connect to the CertStream and proc
 parser.add_argument('--json', action='store_true', help='Output raw JSON to the console.')
 parser.add_argument('--full', action='store_true', help='Output all SAN addresses as well')
 parser.add_argument('--disable-colors', action='store_true', help='Disable colors when writing a human readable ')
+parser.add_argument('--verbose', action='store_true', default=False, dest='verbose', help='Display debug logging.')
 
 def main():
     args = parser.parse_args()
 
     # Ignore broken pipes
     signal(SIGPIPE, SIG_DFL)
+
+    log_level = logging.INFO
+    if args.verbose:
+        log_level = logging.DEBUG
+
+    logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=log_level)
 
     def _handle_messages(message, context):
         if args.json:

--- a/certstream/core.py
+++ b/certstream/core.py
@@ -43,7 +43,6 @@ class CertStreamClient(WebSocketApp):
         logging.error("Error connecting to CertStream - {} - Sleeping for a few seconds and trying again...".format(ex))
 
 def listen_for_events(message_callback, skip_heartbeats=True):
-    logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)
     try:
         while True:
             c = CertStreamClient(message_callback, skip_heartbeats=skip_heartbeats)


### PR DESCRIPTION
Its possible that this guy could be called from a non-MainThread,  or prior to another logging.basicConfig call being done.

This could result in disrupting a parent application's logging strategy.