### PR TITLE
I've created a working snap for certstream-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ It leverages the excellent 2/3 compatible [websocket-client](https://github.com/
 ```
 pip install certstream
 ```
+# Or install the snap
+
+```
+sudo snap install certstream
+```
 
 # Usage
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: certstream # check to see if it's available
+version: '1.0+git' # this is freakin' awesome
+summary: Certstream-Python # 79 char long summary
+description: |
+  Certstream-python is a library for interacting with the certstream network to monitor an aggregated feed from a collection of Certificate Transparency Lists.
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs
+
+apps:
+  certstream:
+    command: certstream
+    plugs:
+      - home
+      - network
+     
+parts: 
+  my-part:
+    source: https://github.com/kz6fittycent/certstream-python
+    source-type: git
+    plugin: python3
+    
+    build-packages:
+      - python3
+      
+    stage-packages:
+      - python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: certstream # check to see if it's available
-version: '1.0+git' # this is freakin' awesome
+version: '1.1+git' # this is freakin' awesome
 summary: Certstream-Python # 79 char long summary
 description: |
   Certstream-python is a library for interacting with the certstream network to monitor an aggregated feed from a collection of Certificate Transparency Lists.


### PR DESCRIPTION
The snap works and is already published. Let me know if you need further assistance/clarification about snaps. 

Basically, it's now "easier" to distribute most Linux distros without needing to create a package for each. 

It's also "self-updating" and won't affect any system libs. 