### PR TITLE
Add parameter to enable/disable logging message

### DIFF
--- a/certstream/core.py
+++ b/certstream/core.py
@@ -15,11 +15,12 @@ class Context(dict):
 class CertStreamClient(WebSocketApp):
     _context = Context()
 
-    def __init__(self, message_callback, url, skip_heartbeats=True, on_open=None, on_error=None):
+    def __init__(self, message_callback, url, skip_heartbeats=True, on_open=None, on_error=None, enable_logging=True):
         self.message_callback = message_callback
         self.skip_heartbeats = skip_heartbeats
         self.on_open_handler = on_open
         self.on_error_handler = on_error
+        self.enable_logging = enable_logging
         super(CertStreamClient, self).__init__(
             url=url,
             on_open=self._on_open,
@@ -28,7 +29,8 @@ class CertStreamClient(WebSocketApp):
         )
 
     def _on_open(self, instance):
-        logging.info("Connection established to CertStream! Listening for events...")
+        if self.enable_logging:
+            logging.info("Connection established to CertStream! Listening for events...")
         if self.on_open_handler:
             self.on_open_handler(instance)
 
@@ -45,17 +47,19 @@ class CertStreamClient(WebSocketApp):
             raise
         if self.on_error_handler:
             self.on_error_handler(instance, ex)
-        logging.error("Error connecting to CertStream - {} - Sleeping for a few seconds and trying again...".format(ex))
+        if self.enable_logging:
+            logging.error("Error connecting to CertStream - {} - Sleeping for a few seconds and trying again...".format(ex))
 
-def listen_for_events(message_callback, url, skip_heartbeats=True, setup_logger=True, on_open=None, on_error=None, **kwargs):
+def listen_for_events(message_callback, url, skip_heartbeats=True, setup_logger=True, on_open=None, on_error=None, enable_logging=True, **kwargs):
     if setup_logger:
         logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)
 
     try:
         while True:
-            c = CertStreamClient(message_callback, url, skip_heartbeats=skip_heartbeats, on_open=on_open, on_error=on_error)
+            c = CertStreamClient(message_callback, url, skip_heartbeats=skip_heartbeats, on_open=on_open, on_error=on_error, enable_logging=enable_logging)
             c.run_forever(**kwargs)
             time.sleep(5)
     except KeyboardInterrupt:
-        logging.info("Kill command received, exiting!!")
+        if enable_logging:
+            logging.info("Kill command received, exiting!!")
 


### PR DESCRIPTION
In case someone is using certstream as a third party lib and doesn't want it's logging messages