### PR TITLE
Working snap for certstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ It leverages the excellent 2/3 compatible [websocket-client](https://github.com/
 ```
 pip install certstream
 ```
+# Or install the snap
+
+```
+sudo snap install certstream
+```
 
 # Usage
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,10 +21,8 @@ parts:
   certstream:
     source: https://github.com/CaliDog/certstream-python
     source-type: git
-    environment:
-      LC_ALL: C.UTF-8
-      LANG: C.UTF-8
-      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
+    plugin: python
+    python-version: python3
     
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: certstream # check to see if it's available
+version: '1.0+git' # this is freakin' awesome
+summary: Certstream-Python # 79 char long summary
+description: |
+  Certstream-python is a library for interacting with the certstream network to monitor an aggregated feed from a collection of Certificate Transparency Lists.
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs
+
+apps:
+  certstream:
+    command: certstream
+    plugs:
+      - home
+      - network
+     
+parts: 
+  my-part:
+    source: https://github.com/kz6fittycent/certstream-python
+    source-type: git
+    plugin: python3
+    
+    build-packages:
+      - python3
+      
+    stage-packages:
+      - python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,10 @@ parts:
   certstream:
     source: https://github.com/CaliDog/certstream-python
     source-type: git
-    plugin: python3
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
     
     override-pull: |
       snapcraftctl pull

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: certstream # check to see if it's available
-version: '1.0+git' # this is freakin' awesome
+version: '1.1+git' # this is freakin' awesome
 summary: Certstream-Python # 79 char long summary
 description: |
   Certstream-python is a library for interacting with the certstream network to monitor an aggregated feed from a collection of Certificate Transparency Lists.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"
     
     build-packages:
       - python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,14 @@
-name: certstream # check to see if it's available
-version: '1.1+git' # this is freakin' awesome
-summary: Certstream-Python # 79 char long summary
+name: certstream
+adopt-info: certstream
+summary: Certstream-Python
 description: |
   Certstream-python is a library for interacting with the certstream network to monitor an aggregated feed from a collection of Certificate Transparency Lists.
-grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: strict # use 'strict' once you have the right plugs
+
+license: MIT
+
+base: core18
+grade: stable
+confinement: strict
 
 apps:
   certstream:
@@ -14,10 +18,14 @@ apps:
       - network
      
 parts: 
-  my-part:
-    source: https://github.com/kz6fittycent/certstream-python
+  certstream:
+    source: https://github.com/CaliDog/certstream-python
     source-type: git
     plugin: python3
+    
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"
     
     build-packages:
       - python3


### PR DESCRIPTION
Hi, 

I've been maintaining the `certstream` snap for some time now. If you're not sure what snaps are, see this [link](https://snapcraft.io/about). 

I'd like to move ownership to you.

It's easy enough to make the transition and I'd love to discuss with you. Here's a link to my [repo](https://github.com/kz6fittycent/certstream-python/blob/master/snap/snapcraft.yaml).

Here's a link to the snap in the [Snap-store](https://snapcraft.io/certstream).

If you're interested: 

Head over to the snapcraft [forum](https://forum.snapcraft.io/) and create an account. Start a post with something like "Transfer ownership of Certstream snap". It'll need to get tagged with "Store".

Explain who you are and that you'd like to transfer the snap to your project. Tag me @kz6fittycent and I'll make sure to dovetail whatever you state.

Once that happens, your same creds are used to log into the build service, etc. This will let you edit the posting, etc. You can then manage releases in your dashboard (e.g. moving edge builds to stable, etc). Any time you make a commit to the branch the snap is tied to, it'll automatically build and release to the edge channel.

The whole thing should take no more than 30 min.

As for Canonical transferring the snap, it might take some time. Last time I did this, it took make 3 days for them to complete it. That was for the `slcli` snap that [SoftLayer](https://github.com/softlayer/softlayer-python) now owns.


Let me know if you'd like to proceed.