### PR TITLE
Invoke on_error_handler as described in the docs

### DIFF
--- a/certstream/core.py
+++ b/certstream/core.py
@@ -44,7 +44,7 @@ class CertStreamClient(WebSocketApp):
         if type(ex) == KeyboardInterrupt:
             raise
         if self.on_error_handler:
-            self.on_error_handler(ex)
+            self.on_error_handler(self, ex)
         certstream_logger.error("Error connecting to CertStream - {} - Sleeping for a few seconds and trying again...".format(ex))
 
 def listen_for_events(message_callback, url, skip_heartbeats=True, setup_logger=True, on_open=None, on_error=None, **kwargs):


### PR DESCRIPTION
According to the example in the README, the `on_error` handler should be called with two parameters, of which the first is the `CertStreamClient` instance:

https://github.com/CaliDog/certstream-python/blob/97eb5b37e2c2077495e20d6df3459088a5262b48/README.md?plain=1#L61-L63