### PR TITLE
Removed signal import on win32

### DIFF
--- a/certstream/cli.py
+++ b/certstream/cli.py
@@ -5,8 +5,6 @@ import logging
 import sys
 import termcolor
 
-from signal import signal, SIGPIPE, SIG_DFL
-
 import certstream
 
 parser = argparse.ArgumentParser(description='Connect to the CertStream and process CTL list updates.')
@@ -21,7 +19,9 @@ def main():
     args = parser.parse_args()
 
     # Ignore broken pipes
-    signal(SIGPIPE, SIG_DFL)
+    if not sys.platform.startswith("win32"):
+        from signal import signal, SIGPIPE, SIG_DFL
+        signal(SIGPIPE, SIG_DFL)
 
     log_level = logging.INFO
     if args.verbose:


### PR DESCRIPTION
# Description
**Issue:** The current code does not run on Windows due to the absence of the `signal` module functionalities for setting `SIGPIPE`.

**Solution:** Added a conditional import and setting of `signal` only if the operating system is not Windows.

# Changes

- Added a check to determine the operating system.
- Imported and set signal only for non-Windows systems.

# Code

```python

if sys.platform != 'win32':
    from signal import signal, SIGPIPE, SIG_DFL
    signal(SIGPIPE, SIG_DFL)
```
    
# Testing
Verified that the code runs without errors on Windows.
Ensured that the signal handling works correctly on non-Windows systems.